### PR TITLE
feat: Add UMA calculator to mbe_automation

### DIFF
--- a/src/mbe_automation/__init__.py
+++ b/src/mbe_automation/__init__.py
@@ -12,6 +12,7 @@ from .calculators import (
     DFT,
     MACE,
     DeltaMACE,
+    UMA,
 )
 
 from .storage.core import (

--- a/src/mbe_automation/calculators/__init__.py
+++ b/src/mbe_automation/calculators/__init__.py
@@ -5,6 +5,7 @@ from . import core
 from .dftb import DFTBCalculator, GFN1_xTB, GFN2_xTB, DFTB_Plus_MBD, DFTB3_D4
 from .pyscf import PySCFCalculator, DFT, HF
 from .mace import MACE, DeltaMACE, _MACE_AVAILABLE
+from .uma import UMA, _UMA_AVAILABLE
 from .core import run_model
 from .core import CALCULATORS
 from .isolated_atoms import atomic_energies

--- a/src/mbe_automation/calculators/core.py
+++ b/src/mbe_automation/calculators/core.py
@@ -35,10 +35,6 @@ def _is_mace(calc) -> bool:
     """Safe isinstance check when MACE may be None (mace package not installed)."""
     return MACE is not None and isinstance(calc, (MACE, DeltaMACE))
 
-def _is_uma(calc) -> bool:
-    """Safe isinstance check when UMA may be None (fairchem package not installed)."""
-    return UMA is not None and isinstance(calc, UMA)
-
 
 def _split_work(structure: Structure, n_workers: int):
     assert structure.atomic_numbers.ndim == structure.masses.ndim
@@ -192,7 +188,7 @@ def _sequential_loop(
 
 
 def _parallel_loop(
-    calculator: MACE | UMA | PySCFCalculator,
+    calculator: CALCULATORS,
     structure: Structure,
     compute_energies: bool,
     compute_forces: bool,
@@ -367,7 +363,7 @@ def run_model(
     use_ray = (
         RAY_AVAILABLE and
         n_workers > 1 and
-        (isinstance(calculator, PySCFCalculator) or _is_mace(calculator) or _is_uma(calculator))
+        (isinstance(calculator, PySCFCalculator) or _is_mace(calculator))
     )
 
     if use_ray:

--- a/src/mbe_automation/calculators/core.py
+++ b/src/mbe_automation/calculators/core.py
@@ -17,21 +17,27 @@ from mbe_automation.storage.core import (
     CALCULATION_STATUS_SCF_NOT_CONVERGED,
 )
 from mbe_automation.calculators.mace import MACE, DeltaMACE, _MACE_AVAILABLE
+from mbe_automation.calculators.uma import UMA, _UMA_AVAILABLE
 from mbe_automation.calculators.pyscf import PySCFCalculator, SCFNotConverged
 from mbe_automation.calculators.dftb import DFTBCalculator
 import mbe_automation.common.display
 import mbe_automation.common.resources
 from mbe_automation.configs.execution import Resources
 
+CALCULATORS = PySCFCalculator | DFTBCalculator
 if _MACE_AVAILABLE:
-    CALCULATORS = PySCFCalculator | DFTBCalculator | MACE | DeltaMACE
-else:
-    CALCULATORS = PySCFCalculator | DFTBCalculator
+    CALCULATORS = CALCULATORS | MACE | DeltaMACE
+if _UMA_AVAILABLE:
+    CALCULATORS = CALCULATORS | UMA
 
 
 def _is_mace(calc) -> bool:
     """Safe isinstance check when MACE may be None (mace package not installed)."""
     return MACE is not None and isinstance(calc, (MACE, DeltaMACE))
+
+def _is_uma(calc) -> bool:
+    """Safe isinstance check when UMA may be None (fairchem package not installed)."""
+    return UMA is not None and isinstance(calc, UMA)
 
 
 def _split_work(structure: Structure, n_workers: int):
@@ -186,7 +192,7 @@ def _sequential_loop(
 
 
 def _parallel_loop(
-    calculator: MACE | PySCFCalculator,
+    calculator: MACE | UMA | PySCFCalculator,
     structure: Structure,
     compute_energies: bool,
     compute_forces: bool,
@@ -336,7 +342,7 @@ else:
 
 def run_model(
     structure: Structure,
-    calculator: MACE | PySCFCalculator | DFTBCalculator,
+    calculator: MACE | UMA | PySCFCalculator | DFTBCalculator,
     compute_energies: bool = True,
     compute_forces: bool = True,
     compute_feature_vectors: bool = True,
@@ -361,7 +367,7 @@ def run_model(
     use_ray = (
         RAY_AVAILABLE and
         n_workers > 1 and
-        (isinstance(calculator, PySCFCalculator) or _is_mace(calculator))
+        (isinstance(calculator, PySCFCalculator) or _is_mace(calculator) or _is_uma(calculator))
     )
 
     if use_ray:

--- a/src/mbe_automation/calculators/core.py
+++ b/src/mbe_automation/calculators/core.py
@@ -338,7 +338,7 @@ else:
 
 def run_model(
     structure: Structure,
-    calculator: MACE | UMA | PySCFCalculator | DFTBCalculator,
+    calculator: CALCULATORS,
     compute_energies: bool = True,
     compute_forces: bool = True,
     compute_feature_vectors: bool = True,

--- a/src/mbe_automation/calculators/uma.py
+++ b/src/mbe_automation/calculators/uma.py
@@ -2,7 +2,7 @@ import torch
 
 try:
     from fairchem.core import pretrained_mlip, FAIRChemCalculator
-    from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
+    from fairchem.core.units.mlip_unit import InferenceSettings
     _UMA_AVAILABLE = True
 except ImportError:
     FAIRChemCalculator = object  # type: ignore[assignment,misc]
@@ -24,7 +24,6 @@ if _UMA_AVAILABLE:
                 task_name: str = "omc",
                 **kwargs
         ):
-            # Auto-detect GPU if not explicitly provided
             if device is None:
                 if torch.cuda.is_available():
                     device = "cuda"
@@ -34,10 +33,8 @@ if _UMA_AVAILABLE:
             self.model_name = model_name
             self.device = device
 
-            # Track the multi-head character in the level_of_theory string
             self.level_of_theory = f"uma_{model_name}_{task_name}_head"
 
-            # Create InferenceSettings with float64 precision
             inference_settings = InferenceSettings(
                 tf32=False,
                 activation_checkpointing=True,
@@ -48,12 +45,8 @@ if _UMA_AVAILABLE:
                 base_precision_dtype=torch.float64
             )
 
-            # Load the pretrained predictor
             predictor = pretrained_mlip.get_predict_unit(model_name, device=self.device, inference_settings=inference_settings)
 
-            # Initialize the base FAIRChemCalculator.
-            # We pass task_name straight to super() here.
-            # DO NOT use self.task_name = task_name!
             super().__init__(predictor, task_name=task_name, **kwargs)
 
         def serialize(self) -> tuple:

--- a/src/mbe_automation/calculators/uma.py
+++ b/src/mbe_automation/calculators/uma.py
@@ -55,7 +55,7 @@ if _UMA_AVAILABLE:
 
         def serialize(self) -> tuple:
             """
-            Returns the class and arguments required to reconstruct the calculator.
+            Return the class and arguments required to reconstruct the calculator.
             Used for passing the calculator to Ray workers for parallel execution.
             """
             return UMA, {

--- a/src/mbe_automation/calculators/uma.py
+++ b/src/mbe_automation/calculators/uma.py
@@ -61,7 +61,7 @@ if _UMA_AVAILABLE:
             return UMA, {
                 "model_name": self.model_name,
                 "device": self.device,
-                "task_name": self.task_name,  # Safely reads the base class property
+                "task_name": self.task_name,
             }
 else:
     UMA = None  # type: ignore[assignment,misc]

--- a/src/mbe_automation/calculators/uma.py
+++ b/src/mbe_automation/calculators/uma.py
@@ -35,7 +35,7 @@ if _UMA_AVAILABLE:
 
             self.level_of_theory = f"uma_{model_name}_{task_name}_head"
 
-            inference_settings = InferenceSettings(
+            config = InferenceSettings(
                 tf32=False,
                 activation_checkpointing=True,
                 merge_mole=False,
@@ -45,7 +45,11 @@ if _UMA_AVAILABLE:
                 base_precision_dtype=torch.float64
             )
 
-            predictor = pretrained_mlip.get_predict_unit(model_name, device=self.device, inference_settings=inference_settings)
+            predictor = pretrained_mlip.get_predict_unit(
+                model_name,
+                device=self.device,
+                inference_settings=config
+            )
 
             super().__init__(predictor, task_name=task_name, **kwargs)
 

--- a/src/mbe_automation/calculators/uma.py
+++ b/src/mbe_automation/calculators/uma.py
@@ -1,0 +1,70 @@
+import torch
+
+try:
+    from fairchem.core import pretrained_mlip, FAIRChemCalculator
+    from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
+    _UMA_AVAILABLE = True
+except ImportError:
+    FAIRChemCalculator = object  # type: ignore[assignment,misc]
+    _UMA_AVAILABLE = False
+
+if _UMA_AVAILABLE:
+    class UMA(FAIRChemCalculator):
+        """
+        ASE Calculator wrapper for the Universal Machine learning potential for
+        Atomistic simulations (UMA).
+
+        Provides a seamless interface within the mbe_automation package, replacing MACE.
+        Handles UMA's multi-head (multi-task) architecture via the 'task_name' argument.
+        """
+        def __init__(
+                self,
+                model_name: str = "uma-s-1p2",
+                device: str | None = None,
+                task_name: str = "omc",
+                **kwargs
+        ):
+            # Auto-detect GPU if not explicitly provided
+            if device is None:
+                if torch.cuda.is_available():
+                    device = "cuda"
+                else:
+                    device = "cpu"
+
+            self.model_name = model_name
+            self.device = device
+
+            # Track the multi-head character in the level_of_theory string
+            self.level_of_theory = f"uma_{model_name}_{task_name}_head"
+
+            # Create InferenceSettings with float64 precision
+            inference_settings = InferenceSettings(
+                tf32=False,
+                activation_checkpointing=True,
+                merge_mole=False,
+                compile=False,
+                external_graph_gen=False,
+                internal_graph_gen_version=2,
+                base_precision_dtype=torch.float64
+            )
+
+            # Load the pretrained predictor
+            predictor = pretrained_mlip.get_predict_unit(model_name, device=self.device, inference_settings=inference_settings)
+
+            # Initialize the base FAIRChemCalculator.
+            # We pass task_name straight to super() here.
+            # DO NOT use self.task_name = task_name!
+            super().__init__(predictor, task_name=task_name, **kwargs)
+
+        def serialize(self) -> tuple:
+            """
+            Returns the class and arguments required to reconstruct the calculator.
+            Used for passing the calculator to Ray workers for parallel execution.
+            """
+            return UMA, {
+                "model_name": self.model_name,
+                "device": self.device,
+                "task_name": self.task_name,  # Safely reads the base class property
+            }
+else:
+    UMA = None  # type: ignore[assignment,misc]


### PR DESCRIPTION
This PR introduces the Universal Machine Learning Potential (UMA) calculator integration into the `mbe_automation` library.

Key features:
1. Seamless integration with the existing `fairchem.core` library to instantiate the UMA predictor.
2. Safe fallback when `fairchem` is not installed (via `_UMA_AVAILABLE` boolean flag), mimicking the current `MACE` implementation pattern.
3. Default `model_name` set to `uma-s-1p2` and `task_name` set to `omc`.
4. Enforces 64-bit precision using `InferenceSettings(base_precision_dtype=torch.float64)`.
5. `UMA` calculator is directly accessible from `mbe_automation`.

---
*PR created automatically by Jules for task [1041786967599351256](https://jules.google.com/task/1041786967599351256) started by @modrzejewski*