### PR TITLE
Fix numerical overflow in Debye model integration

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,0 +1,59 @@
+# Debye Model Integration Report
+
+## 1. Overview
+The Debye model is used in the quasi-harmonic workflow to interpolate/extrapolate the equilibrium cell volume as a function of temperature ($V(T)$). It is primarily implemented in `src/mbe_automation/dynamics/harmonic/eec.py` and utilized within `src/mbe_automation/workflows/quasi_harmonic.py` and `src/mbe_automation/dynamics/harmonic/core.py`.
+
+## 2. Code Path Analysis
+
+### 2.1 Physics Review
+The Debye model implementation aims to calculate the volume and volumetric thermal expansion coefficient using the Debye function $D_3(x)$:
+$V(T) = V_0 + C \cdot T \cdot D_3(\Theta_D / T)$
+
+**Volume Calculation ($V(T)$):**
+The function `_debye_volumes` implements this directly. The Debye function $D_3(x)$ in `_debye_function` is evaluated correctly using `scipy.integrate.quad` for the main regime ($10^{-3} < x \le 50$). Limits are gracefully handled:
+- Small $x$: Taylor expansion $1 - \frac{3}{8}x + \frac{1}{20}x^2$ is used for $x < 10^{-3}$.
+- Large $x$: Asymptotic limit $\frac{\pi^4}{15}$ is used for $x > 50$.
+
+**Thermal Expansion Coefficient ($\alpha_V(T)$):**
+The volumetric thermal expansion coefficient is analytically derived:
+$\alpha_V(T) = \frac{1}{V(T)} \frac{dV(T)}{dT}$
+$\frac{dV(T)}{dT} = C \left[ D_3\left(\frac{\Theta_D}{T}\right) - \frac{\Theta_D}{T} D_3'\left(\frac{\Theta_D}{T}\right) \right]$
+
+The function `_debye_alpha_V` computes this as:
+```python
+alpha_V_predicted[i] = 1 / V_predicted[i] * (
+    C * _debye_function(x) +
+    (-ThetaD / T_i )* C * _debye_function_derivative(x)
+)
+```
+This maps perfectly to the analytical derivation.
+
+**Derivative of Debye Function ($D_3'(x)$):**
+The function `_debye_function_derivative` calculates $\frac{d}{dx}D_3(x)$.
+Using Leibniz rule, $\frac{d}{dx} \left[ \frac{3}{x^3} \int_0^x \frac{z^3}{e^z-1} dz \right] = -\frac{3}{x} D_3(x) + \frac{3}{e^x-1}$.
+The codebase implements this perfectly:
+```python
+dD3dx = -3 / x * D3 + 3 / np.expm1(x)
+```
+**Error Found**: For very large $x$ (which corresponds to $T \to 0$, specifically $x \gtrsim 709$), `np.expm1(x)` overflows, raising a `RuntimeWarning` (or exception if configured as such), which stops execution. The `_debye_function_derivative` function lacks an asymptotic approximation for large $x$, unlike `_debye_function`. For large $x$, the term $\frac{3}{e^x-1}$ approaches $0$, so $D_3'(x) \approx -\frac{3}{x} D_3(x) \approx -\frac{9}{x^4}\frac{\pi^4}{15}$.
+
+### 2.2 Syntax and Imports
+- Imports are standard, utilizing `numpy`, `scipy.integrate`, and `scipy.optimize`.
+- Type hinting is comprehensively applied across the functions.
+- The use of `dataclass` for `DebyeModel` and standard parameter defaults is Pythonic.
+
+### 2.3 Integration into the Workflow
+In `src/mbe_automation/workflows/quasi_harmonic.py`, the predicted volume is fetched via `V = row["V_debye (Å³∕unit cell)"]`. The fallback logic is robust: if `debye_model` fails to fit (e.g., `< 3` points in the trust region), it gracefully logs a warning and falls back to `eos_minimum`.
+
+## 3. Weak Points, Errors, and Recommendations
+
+| Type | Location | Description | Recommendation |
+|------|----------|-------------|----------------|
+| **Error** | `src/mbe_automation/dynamics/harmonic/eec.py` (`_debye_function_derivative`) | `np.expm1(x)` overflows for $x \gtrsim 709$. This occurs when predicting $\alpha_V$ for temperatures near 0 K. | Add an asymptotic limit for large $x$. If $x > 50$, `np.expm1(x)` becomes negligible and can be dropped, leaving `dD3dx = -3 / x * D3`. |
+| **Weak Point** | `src/mbe_automation/dynamics/harmonic/eec.py` (`_debye_alpha_V`) | At $T=0$, $\alpha_V$ is hardcoded to `0.0`. While physically true ($T \to 0 \implies \alpha_V \to 0$), it masks the potential overflow for very small $T > 0$. | Fix the overflow in `_debye_function_derivative` as suggested. The $T=0$ hardcode remains acceptable. |
+| **Weak Point** | `src/mbe_automation/dynamics/harmonic/eec.py` (`_debye_fit_params`) | Hardcoded initial guess `[V[0], 200.0, 0.001]` and bounds `([0.0, 0.0, 0.0], [np.inf, 1000.0, np.inf])`. | Consider inferring the initial guess for `ThetaD` or allowing configuration via `DebyeModel`. For some stiff crystals, $\Theta_D$ might exceed 1000K, hitting the upper bound. |
+| **Weak Point** | `src/mbe_automation/workflows/quasi_harmonic.py` | `effective_volume_curve` fallback logic relies on `interpolated_harmonic_props.debye_model.initialized`, which works well but logs warnings per temperature step if put in a loop (though currently outside). | No change needed, the logic is sound and outside the row loop. |
+
+## 4. Ratings
+- **Code Rating**: 9/10. The physics derivation is incredibly solid and exactly matches theory. The only major flaw is the numerical overflow near 0 K.
+- **Totality of Changes**: The workflow effectively incorporates Debye-based interpolation, enabling sensible zero-point and low-temperature thermal expansion calculations.

--- a/src/mbe_automation/dynamics/harmonic/eec.py
+++ b/src/mbe_automation/dynamics/harmonic/eec.py
@@ -45,9 +45,13 @@ def _debye_function_derivative(x: float) -> float:
     if x < 1.0E-2: # switchover value tested with Mathematica
         dD3dx = -3/8 + 1/10 * x - 1/420 * x**3 + 1/15120 * x**5
 
-    else:
+    elif x < 50:
         D3 = _debye_function(x)
         dD3dx = -3 / x * D3 + 3 / np.expm1(x)
+
+    else:
+        D3 = _debye_function(x)
+        dD3dx = -3 / x * D3
 
     return dD3dx
 


### PR DESCRIPTION
Fixes a numerical overflow in the Debye model integration where `_debye_function_derivative` could raise `RuntimeWarning`/errors due to `np.expm1(x)` overflowing when `T` approaches `0 K`. Also generated a report evaluating the physics implementation.

---
*PR created automatically by Jules for task [877935974711512095](https://jules.google.com/task/877935974711512095) started by @modrzejewski*