### PR TITLE
Comprehensive Review of `rebase_to_reference` EEC implementation

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,0 +1,87 @@
+# Review of `rebase_to_reference` implementation
+
+## 1. Syntax and Structure
+The option `"rebase_to_reference"` was added successfully to `ELECTRONIC_ENERGY_CORRECTION` and is fully integrated into the code paths.
+
+- **`configs.quasi_harmonic.FreeEnergy`**:
+  - Exists as `electronic_energy_correction.is_implicit` (which returns true if `reference_state_forcing == "rebase_to_reference"`).
+  - Validation ensures `eos_sampling="pressure"` is incompatible because thermal pressure is not self-consistent.
+  - Validation ensures `volume_curve="eos_minimum"` must be used. Combining with the Debye volume source is rightly disabled to avoid ambiguity.
+
+- **`workflows.quasi_harmonic`**:
+  - Intercepts `effective_volume_curve = "rebase_to_reference"`.
+  - Bypasses trust region limits correctly (since rebase is a pure algebraic shift).
+  - Skips applying thermal pressure as an external pressure for geometry relaxation, mirroring the exact logic intended.
+  - Plumbs `V_rebased` properly to `df_crystal_eos` and scales atoms appropriately for property generation.
+
+- **`dynamics.harmonic.eec.EEC` and related functions**:
+  - `rebase_volume_to_reference` shifts the volume curve accurately via `config.V_ref - V_approx + V`.
+  - Checks if `config.T_ref` or `config.V_ref` are `None`.
+  - Matches `T_ref` using `np.isclose` with `atol=1e-5` to avoid float comparison issues.
+  - The parameter function `_eec_param` cleanly bypasses fitting and returns 0.0.
+  - `_eec_value` explicitly handles `"rebase_to_reference"` and returns zero array/float.
+  - `_eec_pressure` explicitly handles `"rebase_to_reference"` and returns zero array/float.
+
+- **`dynamics.harmonic.core`**:
+  - Locates `T_ref` and ensures that the minimum is valid. Uses `min_extrapolated` correctly if `filter_out_extrapolated_minimum` is enabled.
+  - Nicely structured console printing.
+
+- **`dynamics.harmonic.display`**:
+  - The rebased curve is explicitly plotted with a distinct line (`tab:green`, dashed, with markers). It provides clear legend entries.
+  - Integration with `eos_curves` correctly plots the new G(V,T) points matching the rebased volume.
+
+## 2. Physics and Correctness
+- **Mechanism**: The rebase algorithm simply post-processes the volume curve `V(T)` so `V_corrected(T_ref) = V_ref` and `dV_corrected/dT = dV/dT`.
+- **Zero Energy Shift**: Since the correction does not modify the underlying electronic energy surface, `_eec_value` and `_eec_pressure` returning exactly `0.0` is physically correct.
+- **Thermodynamic Inconsistencies**: The docstrings (e.g. `rebase_volume_to_reference`) correctly note that "V_corrected(T) no longer equals argmin_V G(V, T) for the original energy surface... other thermodynamic quantities... are not guaranteed to remain self-consistent". This warning is sound physics. Disabling the thermal pressure when rebasing acts as an effective safety mechanism for the geometry relaxations down the line.
+
+## 3. Potential Edge Cases / Bugs
+
+**Silent Error or Ambiguity**:
+- In `_eec_value` and `_eec_pressure`, there is an evaluation flow:
+  ```python
+    E_corr = np.zeros_like(V) if isinstance(V, (np.ndarray, list)) else 0.0
+    ...
+    E_final = E_base + E_corr
+    E_spline = cold_curve["E_el_crystal_spline (kJ∕mol∕unit cell)"](V)
+    return E_final - E_spline
+  ```
+  While `E_corr` is zero, `_eec_value` actually returns `E_base - E_spline`.
+  If a user uses `"rebase_to_reference"` *but also specifies a baseline external curve* (e.g., overriding the MLIP cold curve), `E_base` will be the external curve, and `E_spline` will be the MLIP curve. Thus `_eec_value` will return the difference between the external baseline and the MLIP curve, essentially replacing the MLIP cold curve with the external one.
+  - *Mitigation Check*: In `EECConfig.is_valid()`, there is a check:
+    ```python
+    if self.reference_state_forcing == "rebase_to_reference" and self.override_baseline_curve:
+        raise ValueError(
+            "reference_state_forcing='rebase_to_reference' cannot be combined "
+            "with override_baseline_curve=True. Rebase is a volume-only shift "
+            "that does not modify the energy surface."
+        )
+    ```
+    This explicit check prevents the edge case from ever happening. `E_base` and `E_spline` will always be exactly the same curve (the MLIP curve), so `E_base - E_spline` strictly evaluates to `0.0` inside `_eec_value`. This is highly robust!
+
+- **Float Tolerance matching T_ref**:
+  `matches = np.where(np.isclose(T, config.T_ref, atol=1e-5))[0]`
+  If the user sets `T_ref = 300` but the temperatures sampled were `[100, 200, 301, 400]`, the code raises a `ValueError`. This is a clean error rather than a silent failure.
+
+- **V_rebased interpolation in Display**:
+  In `_eos_curves`:
+  ```python
+        G_rebased_scaled = np.array([
+            np.interp(V_rebased[i], eos.V_interp, G_interp_scaled[i, :], left=np.nan, right=np.nan)
+            for i in range(n_temperatures)
+        ])
+  ```
+  If `V_rebased[i]` falls completely outside `eos.V_interp` (the scanned volume range), it returns `np.nan` and Matplotlib ignores it silently, preventing a crash. This handles extrapolation naturally.
+
+## 4. Assessment and Rating
+
+**Rating: 5/5**
+
+The implementation is thorough, clean, and defensively programmed. It correctly handles the logical propagation of the `"rebase_to_reference"` option throughout the stack (from config, to harmonic core, to the workflow runner, to plotting). It proactively catches incompatible workflow options (like pressure EOS sampling or the Debye model) and throws informative errors.
+
+The underlying physics and mathematical constraints are well documented in the method docstrings, providing transparency that thermodynamic self-consistency is deliberately broken to enforce the structure at `T_ref`.
+
+No bugs or missing imports were found in the inspected paths.
+
+**Suggestions for Future Improvement**:
+- If users frequently encounter `T_ref` not being exactly in the temperature array, you might consider interpolating `V(T_ref)` using a spline on the valid volumes instead of requiring `T_ref` to be explicitly sampled. However, strictly enforcing that `T_ref` is in the simulated set ensures highest fidelity at the reference point without relying on interpolation artifacts.


### PR DESCRIPTION
Evaluated the recent implementation of the "rebase_to_reference" option in `ELECTRONIC_ENERGY_CORRECTION` and its flow through the `mbe_automation` quasi-harmonic execution path.
- Verified parsing in `FreeEnergy` config validation logic.
- Analyzed integration in `workflows.quasi_harmonic`, specifically checking the trust region bypass and decoupling of thermal pressure.
- Confirmed that `_eec_value` and `_eec_pressure` correctly output zero shifting since the rebase is pure volume post-processing.
- Found the implementation cleanly handles edge cases and avoids silent failures when dealing with out-of-bounds `T_ref`. No missing or incorrect imports. Evaluated as highly robust (5/5).

---
*PR created automatically by Jules for task [4347909735750890856](https://jules.google.com/task/4347909735750890856) started by @modrzejewski*