### PR TITLE
docs: add review report for Z'>1 functionality

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,0 +1,41 @@
+# Review of Z'>1 Support in Quasi-Harmonic Workflow
+
+## Overview
+A thorough review of the new functionality related to Z'>1 (multiple molecules in the asymmetric unit) in the quasi-harmonic workflow on the `multiple_molecules_in_asu` branch was performed. The analysis focused on physics, thermodynamics equations, crystallographic edge cases, data structures, and user input validation.
+
+Overall, the implementation introduces solid capabilities to handle complex molecular crystals, seamlessly transitioning from single-molecule logic to multi-molecule sublimation calculations. However, the review revealed several aspects, particularly around high-symmetry edge cases, that may need closer attention or future refinement.
+
+## 1. Physics and Thermodynamics Equations
+The generalized definition of sublimation enthalpy and related properties per *formula unit* works well mathematically. The formula `beta = n_atoms_formula_unit / n_atoms_unit_cell` acts as a scaling factor, allowing unit cell properties to be combined properly with gas-phase molecule properties.
+
+- **Sublimation Enthalpy**: Using a weighted sum of molecular contributions scaled by fractional weights (`nu`) and scaling the crystal properties by `beta` accurately yields a mathematically correct, per-formula-unit combination:
+  `ΔH_sub = -E_latt + ΔE_vib + E_trans_sum + E_rot_sum + kT_sum`
+  This properly avoids the issue of silently incorrect values mentioned in the MD TODO.
+
+- **Volume and Formatting**: `V_molar = V_Ang3 * 1.0E-24 * ase.units.mol * beta` correctly evaluates the volume in `cm³/mol/formula unit`. The subscript generation function `_format_formula_unit(nu)` nicely formats strings like `A₂B₁` ensuring consistent display tables. One minor point is that single formula units (e.g., `A₁`) print as `A₁`, but conventionally "1" is omitted (`A`). This is an aesthetic detail, but does not affect correctness.
+
+## 2. Symmetry and Crystallographic Edge Cases
+When thinking like a crystallographer, handling molecules on special positions (where the crystallographic unit corresponds to half a molecule, for example) presents unique challenges:
+
+- **Molecule Extraction vs. Special Positions:**
+  The `identify_molecules` method unrolls periodic graphs and identifies *contiguous graphs of atoms*. When a molecule sits on a center of inversion or other symmetry elements, the unit cell coordinates may only describe half the molecule. However, since the covalent bond graph is constructed from a supercell and unrolled, `mbe_automation` detects the *full* gas-phase molecule. This implies that even for highly symmetric cases (e.g., Z=2 but the atoms in the asymmetric unit only describe half a molecule), the extracted molecule will be the full intact molecule.
+
+- **Normalization Integer Constraints:**
+  The new validation block checks `assert n_atoms_unit_cell % n_atoms_molecule == 0`.
+  If a structure is extremely highly symmetric such that the primitive unit cell contains only a fractional number of a "full molecule", this logic will fail and raise an exception. Typically, a primitive cell will at least contain a full molecule (or a combination of full molecules), but certain esoteric definitions might theoretically present fractional molecules in a highly minimized primitive representation. Currently, the workflow strictly protects against these by failing early.
+
+- **Rescaling Multiplicities (`_resolve_multiplicities`):**
+  The method converts conventional multiplicity to primitive multiplicity via `numerator = int(ref.multiplicity) * n_atoms_primitive`, ensuring that `numerator % n_atoms_conventional == 0`. It's a robust integer math check, perfectly guarding the system from a user supplying irrational multiplicities or misunderstanding their cell's centering. However, if a user attempts to supply fractional multiplicities due to special positions, the explicit `int()` cast and the type hinting expects whole numbers, preventing unsupported inputs.
+
+## 3. Input Validation and Protection Against User Error
+The newly added validation methods successfully ensure the pipeline operates on valid structures:
+
+- **`_validate_molecule_refs`**: This function is robust. It checks the count of references against `composition.n_molecules_unique`, checks primitive cell stoichiometry, and verifies the multiplicity multiset.
+- **Composition Checks**: By comparing the atomic numbers `np.bincount(composition.molecules_unique[k].atomic_numbers...)`, the `replicated_reference=True` workflow perfectly ensures the user doesn't accidentally pass a single gas-phase molecule to a cell with chemically distinct species (like a co-crystal or solvate).
+
+## 4. Code Syntax and Data Structures
+- **Pandas Concatenation**: The introduction of `_tag_molecule_dfs_for_concat` effectively prevents duplicate column errors during Pandas concatenation by appending `[A]`, `[B]`, etc., to the relevant properties for multiple unique molecules.
+- **Type Casting & Numpy GCD**: Calling `np.gcd.reduce(n_equivalent)` correctly discovers the greatest common divisor for multiple unique components. Handling the `n_equivalent` vector with pure NumPy primitives guarantees speed and type safety across integer arrays.
+
+## Summary
+The multiple-molecule implementation logic is robust, mathematically sound, and rigorously safeguarded against user misconfigurations. Highly symmetric edge cases (e.g. molecules situated on symmetry planes) are well-managed via `pymatgen` graph unrolling which assembles the complete gas-phase molecule before matching, though users must be aware that non-integer molecular occupancies per primitive cell will be deliberately rejected.


### PR DESCRIPTION
Adds the requested Markdown report (`report.md`) containing a deep crystallographic review of the new Z'>1 functionality, as required by the user. No code changes were made as requested.

---
*PR created automatically by Jules for task [9747629525531775052](https://jules.google.com/task/9747629525531775052) started by @modrzejewski*