### PR TITLE
docs: fix grammar and phrasing issues

### DIFF
--- a/docs/00_installation.md
+++ b/docs/00_installation.md
@@ -1,4 +1,4 @@
-# Installation
+# Setup & Installation
 
 - [Quick Start: Most Frequent Scenarios](#quick-start-most-frequent-scenarios)
   - [Scenario A: Install with MACE and PySCF on GPU](#scenario-a-install-with-mace-and-pyscf-on-gpu)

--- a/docs/01_api.md
+++ b/docs/01_api.md
@@ -518,8 +518,6 @@ Wraps the ASE `Dftb` calculator. **Stateless** design. Factory functions like `G
 
 The `mbe_automation` library stores all its persistent data in HDF5 files. The following utility functions and classes are provided for reading, inspecting, querying, and managing datasets.
 
-The `mbe_automation` library stores all its persistent data in dataset files. The following utility functions and classes are provided for reading, inspecting, querying, and managing datasets.
-
 ### `read`
 Loads any supported system type from a dataset file automatically based on the stored internal `dataclass` attribute.
 ```python

--- a/docs/01_api.md
+++ b/docs/01_api.md
@@ -516,7 +516,7 @@ Wraps the ASE `Dftb` calculator. **Stateless** design. Factory functions like `G
 
 ## 7. Data Storage & Retrieval
 
-The `mbe_automation` library stores all its persistent data in HDF5 files. The following utility functions and classes are provided for reading, inspecting, querying, and managing datasets.
+The `mbe_automation` library stores all its persistent data in dataset files. The following utility functions and classes are provided for reading, inspecting, querying, and managing datasets.
 
 ### `read`
 Loads any supported system type from a dataset file automatically based on the stored internal `dataclass` attribute.

--- a/docs/06_quasi_harmonic.md
+++ b/docs/06_quasi_harmonic.md
@@ -14,7 +14,7 @@ This workflow performs a quasi-harmonic calculation of thermodynamic properties,
 
 ## Setup
 
-The initial setup involves importing the necessary modules and defining the system's initial structures and the machine learning interatomic potential (MLIP) calculator.
+Setup involves importing necessary modules and defining the system's structures and the machine learning interatomic potential (MLIP) calculator.
 
 ```python
 import numpy as np

--- a/docs/07_molecular_dynamics.md
+++ b/docs/07_molecular_dynamics.md
@@ -10,7 +10,7 @@ This workflow is designed for performing molecular dynamics (MD) simulations to 
 
 ## Setup
 
-The initial setup requires importing the necessary modules and defining the system's structures and the MLIP calculator.
+Setup involves importing necessary modules and defining the system's structures and the machine learning interatomic potential (MLIP) calculator.
 
 ```python
 import numpy as np

--- a/docs/08_training_set.md
+++ b/docs/08_training_set.md
@@ -13,7 +13,7 @@
   - [`FiniteSubsystemFilter`](#finitesubsystemfilter-class)
   - [`PhononFilter`](#phononfilter-class)
 - [Subsampling](#subsampling)
-- [Updates to and Existing Dataset](#updates-to-an-existing-dataset)
+- [Updates to an Existing Dataset](#updates-to-an-existing-dataset)
 - [Computational Bottlenecks](#computational-bottlenecks)
 - [Complete Input Files](#complete-input-files)
 
@@ -21,7 +21,7 @@ This workflow generates a diverse set of configurations for delta-learning a mac
 
 ## Setup
 
-The initial setup involves importing the necessary modules and defining the parameters for the workflow.
+Setup involves importing necessary modules and defining the parameters for the workflow.
 
 ```python
 import numpy as np


### PR DESCRIPTION
This submission fixes grammar, awkward language constructs, and duplicate paragraphs in the `docs/` directory, while adhering to the minimalist style rule of combining Setup and Installation headers where appropriate.

---
*PR created automatically by Jules for task [18044673497956214028](https://jules.google.com/task/18044673497956214028) started by @modrzejewski*