### PR TITLE
docs: Add Phonopy 4.x compatibility report

### DIFF
--- a/PHONOPY_v4_COMPATIBILITY.md
+++ b/PHONOPY_v4_COMPATIBILITY.md
@@ -1,0 +1,167 @@
+
+# Compatibility Report: `mbe-automation` and Phonopy 4.x
+
+## Executive Summary
+
+Phonopy underwent a major release with version 4.0.0 (May 2026), bringing significant breaking changes and shifting to a Rust-based backend (`phonors`) by default. Subsequent 4.x versions (specifically 4.2.0) further refactored the API, changing how results from calculations (e.g., band structures, thermal properties, and meshes) are returned and accessed.
+
+The current `mbe-automation` codebase is pinned to `phonopy==2.43.2` (as per `pyproject.toml`) and heavily relies on phonopy’s Python API. To ensure compatibility with Phonopy 4.x, several targeted modifications are necessary across the `mbe_automation.dynamics.harmonic` module. The primary areas of incompatibility involve the `Phonopy` object initialization, the `run_*` execution methods, and the structural changes to the results returned by these methods.
+
+This report details these changes with code examples, explanations of the discrepancies between the versions, and proposed updates.
+
+---
+
+## Detailed Breakdown and Code Snippets
+
+### 1. `run_*` Methods and Result Objects (v4.2.0)
+
+**The Change:**
+In Phonopy v4.2.0, all `run_*` methods (like `run_band_structure`, `run_thermal_properties`, `run_mesh`) were changed to return dedicated result objects (e.g., `BandStructure`, `ThermalProperties`, `Mesh`).
+While `mbe-automation` did not use the now-deprecated `.get_*_dict()` methods, it relied on accessing the computed properties via attributes like `phonons.band_structure.frequencies` and `phonons.thermal_properties.thermal_properties`. Although some of these attributes might still exist, the canonical and safest way in 4.x is to interact with the returned result objects directly.
+
+**Affected Area 1: Band Structure (`mbe_automation.dynamics.harmonic.data`)**
+
+*Current Code (phonopy v2.x):*
+```python
+    print(f"Calculating band structure...", end="", flush=True)
+    phonons.run_band_structure(
+        bands,
+        with_eigenvectors=False,
+        with_group_velocities=False,
+        is_band_connection=band_connection,
+        path_connections=path_connections,
+        labels=labels
+    )
+    print(f" done (Δt={time.time() - t0:.1f} s)", flush=True)
+```
+Later in `detect_imaginary_modes`, the code assumes `phonons.band_structure` is populated:
+```python
+    n_bands = len(phonons.band_structure.frequencies[0][0])
+    ...
+    for segment_idx in range(len(phonons.band_structure.frequencies)):
+        freqs = phonons.band_structure.frequencies[segment_idx]
+```
+
+*Proposed Update for 4.x:*
+While the stateful `phonons.band_structure` might still be present, it's safer and cleaner to capture the return value directly as per the v4.2.0 change:
+```python
+    print(f"Calculating band structure...", end="", flush=True)
+    bs_result = phonons.run_band_structure(
+        bands,
+        with_eigenvectors=False,
+        with_group_velocities=False,
+        is_band_connection=band_connection,
+        path_connections=path_connections,
+        labels=labels
+    )
+    # Update detect_imaginary_modes to accept the bs_result instead of relying on state
+    # e.g., n_bands = len(bs_result.frequencies[0][0])
+```
+
+**Affected Area 2: Thermal Properties (`mbe_automation.dynamics.harmonic.data`)**
+
+*Current Code (phonopy v2.x):*
+```python
+    phonons.run_thermal_properties(temperatures=temperatures)
+    # ...
+    _, F_vib_crystal, S_vib_crystal, C_V_vib_crystal = phonons.thermal_properties.thermal_properties
+    ZPE_crystal = phonons.thermal_properties.zero_point_energy
+```
+
+*Proposed Update for 4.x:*
+Capture the returned `ThermalProperties` object:
+```python
+    tp_result = phonons.run_thermal_properties(temperatures=temperatures)
+    # ...
+    # Access properties directly from the result object
+    # (Note: exact property structure on tp_result should be verified against v4 docs)
+    _, F_vib_crystal, S_vib_crystal, C_V_vib_crystal = tp_result.thermal_properties
+    ZPE_crystal = tp_result.zero_point_energy
+```
+
+**Affected Area 3: Mesh Generation (`mbe_automation.dynamics.harmonic.core`)**
+
+*Current Code (phonopy v2.x):*
+```python
+    phonons.run_mesh(
+        mesh=interp_mesh,
+        is_gamma_center=True
+    )
+```
+Later code in `data.py` uses `phonons.mesh.qpoints`.
+
+*Proposed Update for 4.x:*
+```python
+    mesh_result = phonons.run_mesh(
+        mesh=interp_mesh,
+        is_gamma_center=True
+    )
+    # Access mesh_result.qpoints instead of phonons.mesh.qpoints
+```
+
+### 2. `Phonopy` Class Initialization (v4.0.0)
+
+**The Change:**
+In Phonopy v4.0.0, the `primitive_matrix` default was changed to `"auto"`. Furthermore, the C-extension is no longer the default; it has been entirely replaced by a Rust backend (`phonors`).
+
+**Affected Area (`mbe_automation.dynamics.harmonic.core.py`):**
+*Current Code:*
+```python
+    phonons = phonopy.Phonopy(
+        phonopy_struct,
+        # ...
+        supercell_matrix=supercell_matrix.T,
+        primitive_matrix=np.eye(3)
+    )
+```
+
+**Explanation:**
+The `mbe-automation` code explicitly passes `primitive_matrix=np.eye(3)`. In Phonopy 4.0.0+, users wanting the identity matrix can pass `"P"`, but `np.eye(3)` (or an equivalent identity matrix array) is typically still valid as an explicit array override. However, to explicitly align with the new v4 convention for a primitive identity transformation, passing `"P"` is the new recommended approach.
+
+Additionally, because the Rust backend (`phonors`) is now the default, this is largely transparent to the Python API, but it enforces an environment dependency (`phonors` >= 0.3.0). The codebase shouldn't need code changes for the backend switch unless it relied on specific C-extension quirks.
+
+*Proposed Update for 4.x:*
+```python
+    phonons = phonopy.Phonopy(
+        phonopy_struct,
+        supercell_matrix=supercell_matrix.T,
+        primitive_matrix="P"  # Updated to the new v4.0.0 convention for identity
+    )
+```
+
+
+### 3. Non-Analytical Term Correction (NAC) Parameter Behavior (v4.0.0)
+
+**The Change:**
+In v4.0.0, the explicit `--nac` flag in the CLI was removed, and NAC is now enabled automatically if `nac_params` are provided. A new `NacParams` TypedDict was introduced in v4.2.0.
+
+**Explanation:**
+`mbe-automation` handles NAC through the API rather than the CLI. If `mbe-automation` explicitly sets `phonons.nac_params = ...` (or passes it to calculators), it should continue to work. However, developers should be aware that if they ever programmatically passed `is_nac=True` to methods like `run_band_structure`, it might be redundant or deprecated, as the presence of `nac_params` on the object automatically triggers NAC behavior in 4.x.
+
+
+### 4. Symmetry and Mesh Sampling Changes (v4.0.0)
+
+**The Change:**
+Phonopy v4.0.0 altered how sampling meshes behave when they break the primitive-cell point-group symmetry. Meshes specified by a length (float input) are now rebuilt as a generalized regular grid that strictly keeps full point-group symmetry.
+
+**Explanation:**
+This may lead to slight numerical differences in mesh-based calculations (like thermal properties) between v2.43.2 and v4.x within `mbe-automation`. The `interp_mesh` passed to `run_mesh` in `mbe_automation.dynamics.harmonic.core` will now be subjected to this stricter symmetry enforcement, potentially altering the exact q-point weights and densities. This requires verification via unit tests (comparing v2 numerical outputs vs v4 outputs for thermodynamic properties).
+
+
+### 5. Displacement Generation Behavior (v4.5.0 / Unreleased / v4.x context)
+
+**The Change:**
+While v4.4.0 is the current stable, upcoming changes (or recent changes in 4.x displacement handling depending on exact version) alter the default for generating displacements (e.g., dropping forced plus-minus pairs for MLPs).
+
+**Explanation:**
+`mbe-automation` currently calls `phonons.generate_displacements(distance=supercell_displacement)`. It should be verified whether `mbe-automation` expects plus-minus pairs strictly. If so, future-proofing the call to explicitly request PM pairs (if the API allows it, equivalent to `--pm auto`) is recommended.
+
+---
+
+## Conclusion and Next Steps
+
+To migrate `mbe-automation` to Phonopy 4.x safely:
+1. **Refactor Result Access**: Modify all `phonons.run_*` calls in `mbe_automation/dynamics/harmonic/data.py` and `core.py` to capture and use the returned result objects (e.g., `bs_result`, `tp_result`) instead of accessing stateful attributes like `phonons.thermal_properties`.
+2. **Update `Phonopy` Instantiation**: Change `primitive_matrix=np.eye(3)` to `primitive_matrix="P"` in `mbe_automation/dynamics/harmonic/core.py`.
+3. **Verify Thermodynamics**: Run existing thermodynamics tests and verify that the stricter symmetry grid enforcement introduced in v4.0.0 does not produce unacceptable numerical deviations from the baseline data.
+4. **Update `pyproject.toml`**: Once code changes are made, update the dependency to `phonopy>=4.4.0` (or `phonopy>=4.0.0`) and ensure `phonors` is available in the environment.

--- a/PHONOPY_v4_COMPATIBILITY.md
+++ b/PHONOPY_v4_COMPATIBILITY.md
@@ -144,9 +144,55 @@ In v4.0.0, the explicit `--nac` flag in the CLI was removed, and NAC is now enab
 **The Change:**
 Phonopy v4.0.0 altered how sampling meshes behave when they break the primitive-cell point-group symmetry. Meshes specified by a length (float input) are now rebuilt as a generalized regular grid that strictly keeps full point-group symmetry.
 
-**Explanation:**
-This may lead to slight numerical differences in mesh-based calculations (like thermal properties) between v2.43.2 and v4.x within `mbe-automation`. The `interp_mesh` passed to `run_mesh` in `mbe_automation.dynamics.harmonic.core` will now be subjected to this stricter symmetry enforcement, potentially altering the exact q-point weights and densities. This requires verification via unit tests (comparing v2 numerical outputs vs v4 outputs for thermodynamic properties).
+**Explanation and Source Code Analysis:**
+In phonopy versions prior to v4.0.0 (e.g., 3.x), if a requested grid broke point-group symmetry (e.g., due to an incompatible half-grid shift), `phonopy` would simply warn the user and fall back to using only time-reversal symmetry (dropping point-group symmetry).
 
+*Phonopy 3.x Logic (Simplified `phonopy/phonon/mesh.py`):*
+```python
+            if "Grid symmetry is broken" in str(exc):
+                warnings.warn(
+                    "BZGrid construction with point-group symmetry failed... "
+                    "Falling back to time-reversal-only ir-grid reduction.",
+                )
+                self._bzgrid = BZGrid(
+                    self._mesh,
+                    lattice=lattice,
+                    is_shift=self._is_shift,
+                    is_time_reversal=is_time_reversal, # Point group symmetry effectively dropped
+                )
+```
+
+In phonopy 4.x, this fallback has been significantly improved. To preserve full point-group symmetry when a length-based mesh breaks symmetry on the primitive cell, the grid is now automatically rebuilt as a **generalized regular grid (GRG)** anchored to the conventional cell.
+
+*Phonopy 4.x Logic (`phonopy/phonon/mesh.py` - `_fallback_bzgrid`):*
+```python
+        if mesh_length is not None and primitive_symmetry is not None:
+            try:
+                self._bzgrid = BZGrid(
+                    float(mesh_length),
+                    lattice=lattice,
+                    symmetry_dataset=primitive_symmetry.dataset,
+                    is_shift=self._is_shift,
+                    is_time_reversal=is_time_reversal,
+                    use_grg=True, # <--- Uses generalized regular grid!
+                    lang=lang,
+                )
+                old_mesh = self._mesh.tolist()
+                self._mesh = np.array(self._bzgrid.D_diag, dtype="int64")
+                warnings.warn(
+                    f"Mesh {old_mesh} from length input {float(mesh_length)} "
+                    f"is incompatible with the primitive-cell point group; "
+                    f"rebuilt as a generalized regular grid "
+                    f"(D_diag={self._mesh.tolist()}) anchored to the "
+                    f"conventional cell to keep full point-group symmetry. "
+                    f"mesh_numbers may differ from the regular-grid value.",
+                    MeshGRGridFallbackWarning,
+```
+
+**Impact on `mbe-automation`:**
+Because the mesh is rebuilt into a GR-grid anchored to the conventional cell, the resulting mesh dimensions (`self._mesh`) and q-point weights may differ numerically from what `length2mesh` would have naively generated in v2.x/v3.x.
+
+Consequently, mesh-based thermodynamic calculations (like thermal properties) triggered via `run_mesh` in `mbe_automation.dynamics.harmonic.core` will now be subjected to this stricter symmetry grid enforcement. If any unit tests in `mbe-automation` hardcode exact expected thermodynamic quantities based on these asymmetric meshes, they will need to be updated to match the new, highly symmetric outputs.
 
 ### 5. Displacement Generation Behavior (v4.5.0 / Unreleased / v4.x context)
 


### PR DESCRIPTION
This PR adds a thorough markdown report `PHONOPY_v4_COMPATIBILITY.md` detailing the upcoming migration steps needed for Phonopy 4.x. It does not introduce any Python code changes, remaining safely focused on the reporting requirements.

---
*PR created automatically by Jules for task [13373036185249518657](https://jules.google.com/task/13373036185249518657) started by @modrzejewski*