### PR TITLE
docs: add MBE workflow audit report

### DIFF
--- a/mbe_audit_report.md
+++ b/mbe_audit_report.md
@@ -1,0 +1,83 @@
+# Many-Body Expansion Workflow Audit Report
+
+## 1. Executive Summary
+
+This report presents a thorough audit of the Many-Body Expansion (MBE) workflow implemented in `mbe-automation`. The audit traces the execution path starting from the main workflow driver (`src/mbe_automation/workflows/many_body_expansion.py`), through cluster generation, structure matching, and data export. Special emphasis has been placed on scrutinizing the molecule/cluster matching logic, specifically the handling of atom permutations and mirror images (`align_mirror_images=True`).
+
+The codebase shows a thoughtful, layered architecture where workflows leverage configuration dataclasses and delegate heavy lifting to specialized modules (`structure.clusters`, `structure.molecule`, `storage.core`).
+
+## 2. Execution Path Analysis
+
+The main entry point for the workflow is `run()` in `src/mbe_automation/workflows/many_body_expansion.py`. The execution flow is logically structured as follows:
+
+1.  **Initialization and Storage**: The computational resources are printed, and the initial crystal structure (`config.crystal`) is saved to the designated HDF5 dataset using `mbe_automation.storage.save_structure`.
+2.  **Molecule Identification (`identify_molecules`)**: The workflow analyzes the covalent bond graph of the crystal to identify unique molecules, returning a `MolecularComposition` object. By default, it uses `match_mode="energy_only"`, which requires a valid ASE calculator.
+3.  **Supercell Expansion (`expand_to_supercell`)**: The identified unique molecules are propagated into a supercell whose size is dynamically determined based on the maximum intermolecular distance cutoff defined in the config. This produces a `SupercellMolecules` object.
+4.  **Symmetry-Unique Cluster Extraction (`symmetry_unique_clusters`)**: This is the core algorithmic step. It iterates over the target cluster sizes (monomers, dimers, trimers, etc.) and performs filtering based on characteristic distances (e.g., minimum intermolecular distance $r_{ij}$). This step relies heavily on the `match` function in `mbe_automation.structure.molecule` to identify symmetrically equivalent clusters.
+5.  **Output Generation**: Finally, the unique clusters are stored in the HDF5 dataset. Depending on the config flags (`save_xyz`, `save_csv`, `save_inputs`, `save_plots`), XYZ coordinates, CSV summaries, electronic structure input files (e.g., MRCC), and diagnostic plots are generated.
+
+## 3. Scrutiny of Structure Matching & Permutations Logic
+
+A critical aspect of the MBE workflow is correctly identifying whether two molecular clusters are symmetry-equivalent. The `mbe_automation.structure.molecule.match` function handles this, returning the Root Mean Square Deviation (RMSD) between two atomic configurations.
+
+### 3.1. The `align_mirror_images=True` Flag
+In the context of the MBE workflow (specifically lattice energy calculation), isomer-dependent properties (like chirality) are generally not the primary concern—energetics are. Therefore, `align_mirror_images=True` is hardcoded in `clusters.py` during the `fast_compare` check within `_symmetry_unique_clusters`.
+
+**Implementation details**:
+Across all backends (`ase`, `pymatgen`, `irmsd`), mirror imaging is implemented by simply applying a reflection across the y-axis:
+```python
+positions_b_mirror = positions_b * [1, -1, 1]
+```
+The algorithm computes the RMSD for both the original `positions_b` and `positions_b_mirror`, returning the minimum of the two. This is computationally cheap and effective for checking enantiomeric equivalence.
+
+### 3.2. Backends and Permutation Handling
+
+The `match` function supports three algorithms: `ase`, `pymatgen`, and `irmsd`.
+
+**A. `ase` backend (`_match_ase`)**
+*   **Mechanism**: Uses `ase.geometry.distance`. ASE attempts to align the structures by centering them at the origin and rotating them to align their principal axes of inertia.
+*   **Permutations**: ASE does *not* explicitly search through atom permutations. It assumes that the ordering of atoms in the two input arrays is identical.
+*   **Drawback**: If the molecular clusters are generated such that equivalent atoms appear in different orders, the `ase` backend will fail to match them, leading to an over-counting of "unique" clusters. It can also fail for highly symmetric molecules where principal axes are degenerate.
+
+**B. `pymatgen` backend (`_match_pymatgen`)**
+*   **Mechanism**: Uses `pymatgen.analysis.molecule_matcher.HungarianOrderMatcher`. This is a much more robust approach.
+*   **Permutations**: The Hungarian algorithm solves the assignment problem. It optimally matches atoms of the same species between the two structures to minimize the distance, effectively handling arbitrary atom permutations without combinatorial explosion. It optimally aligns the molecules using the Kabsch algorithm.
+*   **Correction**: `pymatgen` computes the RMSD over a flattened $3N$-dimensional vector. The implementation correctly rescales this using `np.sqrt(3.0) * rmsd` to match the standard definition $\sqrt{\frac{1}{N} \sum (\mathbf{r}_i - \mathbf{r}'_i)^2}$.
+
+**C. `irmsd` backend (`_match_irmsd`)**
+*   **Mechanism**: Uses the external `irmsd` C-extension library (Independent RMSD).
+*   **Permutations**: This library is specifically designed to calculate the minimum RMSD over all permutations of identical atoms. It uses a graph-theory approach or optimized combinatorial searches to find the best mapping. It is the default algorithm (`DEFAULT_MATCH_ALGO`).
+*   **Drawback**: It is an optional dependency. If it's missing, the code gracefully raises an `ImportError`.
+
+### 3.3. Bottlenecks in Clustering (`clusters.py`)
+
+The identification of reducible clusters (`_filter_candidates_by_min_rij`) uses `itertools.combinations` and `itertools.product` to generate candidate clusters.
+
+*   **`_candidate_distances`**: Pre-computes minimum and maximum distance matrices between all candidate molecules. This is an efficient, fully vectorized operation using `scipy.spatial.distance.cdist`.
+*   **Combinatorial generation**: The generator `cands_per_u` uses `itertools.combinations` to select instances of each unique molecule type. While this scales as $O(N^K)$ where $N$ is the number of candidates and $K$ is the cluster size, the pre-filtering of candidates (`_candidates_within_sphere`) based on the `max_cutoff` drastically reduces $N$, making this approach feasible for typical MBE expansions (up to tetramers/pentamers).
+*   **Distance Filtering**: The boolean array `within_cutoff` is constructed efficiently by indexing the precomputed distance matrices (`min_rij`) using the generated combinations (`all_clusters`).
+
+### 3.4. Fast Comparison (`fast_compare`)
+Before invoking the relatively expensive `RMSD` matching (especially with permutations), `_symmetry_unique_clusters` uses a `fast_compare` heuristic:
+```python
+if reducible.fast_compare(cluster_idx, ref_cluster_idx):
+    # Proceed to expensive RMSD calculation
+```
+This checks if the sorted minimum intermolecular distances of the two clusters are identical (within `alignment_thresh`). Because intermolecular distances are invariant under rotation, translation, and atom permutation, this is a highly effective, $O(1)$ negative screen.
+
+## 4. Architectural & Code Quality Observations
+
+*   **Type Hinting**: The codebase makes extensive and proper use of type hinting (e.g., `npt.NDArray[np.float64]`, `Tuple`, `Dict`), which greatly enhances readability and static analysis.
+*   **Data Structures**: The use of dataclasses (`MBE`, `UniqueClustersFilter`, `SupercellMolecules`, `UniqueClusters`) centralizes the state and makes the APIs clean. The mutable `_ClusterAccumulator` used during the symmetry reduction loop is a nice touch to avoid repeatedly appending to numpy arrays.
+*   **Documentation**: Docstrings are generally good, explaining the expected shapes of arrays (e.g., in `ReducibleClusters`).
+*   **Memory Management**: In `_symmetry_unique_clusters`, generating combinations for very large cutoffs could potentially cause memory spikes due to `all_clusters = np.array([...])`. However, in standard physical scenarios, the number of molecules within a 15-30 Å cutoff is tractable.
+
+## 5. Conclusions & Recommendations
+
+The MBE workflow is well-architected. The logic for generating supercells, filtering distance matrices, and performing symmetry reduction is sound.
+
+**Specific Recommendations regarding Permutations:**
+1.  **Deprecate/Warn on ASE backend**: Given that the supercell generation shifts molecules around, there is no guarantee that the internal atom ordering of two symmetrically equivalent clusters remains identical. The `ase` backend should likely print a warning if used, as it does not handle permutations and could lead to incorrect symmetry reduction.
+2.  **Rely on `pymatgen` or `irmsd`**: The default to `irmsd` (and `pymatgen` as a robust alternative) is correct. The scaling factor $\sqrt{3}$ applied to the `pymatgen` RMSD result is correctly implemented.
+
+The workflow is ready for further stages of implementation (e.g., SLURM integration).


### PR DESCRIPTION
Added an audit report for the many-body expansion workflow, specifically scrutinizing how atom permutations and mirror images are handled during structure matching.

---
*PR created automatically by Jules for task [4829710337027437437](https://jules.google.com/task/4829710337027437437) started by @modrzejewski*